### PR TITLE
Improve dark mode and sidebar

### DIFF
--- a/src/layout/components/PageSider/index.vue
+++ b/src/layout/components/PageSider/index.vue
@@ -2,7 +2,6 @@
   <div>
     <el-menu
       class="el-menu-vertical-demo"
-      background-color="#c6e2f1"
       text-color="#000000"
       active-text-color="#ffffff"
       router
@@ -99,10 +98,12 @@ export default {
 .el-menu {
   height: 100%;
   border-right: 0;
+  background: linear-gradient(180deg, #c6e2f1 0%, #e6f6fb 100%);
   }
 .MenuBackground{
-  background: url("../../../assets/MenuBackGround.jpg");
-  background-size: 120%;
+  background: linear-gradient(rgba(255,255,255,0.8), rgba(255,255,255,0.8)), url("../../../assets/MenuBackGround.jpg");
+  background-size: cover;
+  background-repeat: no-repeat;
   height: 844px;
   }
 </style>

--- a/src/style/reset.css
+++ b/src/style/reset.css
@@ -225,8 +225,8 @@ body,
   background-color: #f3f3f4;
 }
 body.dark-mode {
-  background-color: #000;
-  color: #fff;
+  background-color: #1e1e1e;
+  color: #eee;
 }
 body.dark-mode a {
   color: #91b5ff;
@@ -235,14 +235,20 @@ body.dark-mode .el-container,
 body.dark-mode .el-header,
 body.dark-mode .el-main,
 body.dark-mode .el-aside {
-  background-color: #000 !important;
-  color: #fff;
+  background-color: #1e1e1e !important;
+  color: #eee;
 }
 body.dark-mode input,
 body.dark-mode textarea,
 body.dark-mode .el-input__inner {
   background-color: #333;
   color: #fff;
+}
+body.dark-mode .el-table,
+body.dark-mode .el-table th,
+body.dark-mode .el-table td {
+  background-color: #1e1e1e !important;
+  color: #eee;
 }
 @font-face {
   font-family: "icomoon";


### PR DESCRIPTION
## Summary
- tweak dark mode colors for better readability
- update sidebar background to a gradient overlay

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdc1761d8832ca241eca64bf4515c